### PR TITLE
Add timebase for effects property

### DIFF
--- a/src/Kevsoft.WLED/StateRequest.cs
+++ b/src/Kevsoft.WLED/StateRequest.cs
@@ -51,7 +51,14 @@ public sealed class StateRequest
     [JsonPropertyName("seg")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public SegmentRequest[]? Segments { get; set; } = null!;
-        
+
+    /// <summary>
+    /// Timebase for effects.
+    /// </summary>
+    [JsonPropertyName("tb")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Timebase { get; set; }
+
     public static StateRequest From(StateResponse stateResponse)
     {
         return new StateRequest()


### PR DESCRIPTION
Adds the `tb` timebase property for effects. Because it's not reported, it's only added to the `StateRequest`, not the response.