### PR TITLE
Added Freeze to SegmentRequest

### DIFF
--- a/src/Kevsoft.WLED/SegmentRequest.cs
+++ b/src/Kevsoft.WLED/SegmentRequest.cs
@@ -72,6 +72,11 @@ public sealed class SegmentRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Reverse { get; set; }
 
+    /// <inheritdoc cref="SegmentResponse.Freeze"/>
+    [JsonPropertyName("frz")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Freeze { get; set; }
+
     /// <inheritdoc cref="SegmentResponse.SegmentState"/>
     [JsonPropertyName("on")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -86,7 +91,6 @@ public sealed class SegmentRequest
     [JsonPropertyName("mi")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Mirror { get; set; }
-
 
     public static SegmentRequest From(SegmentResponse segmentResponse)
     {
@@ -106,6 +110,7 @@ public sealed class SegmentRequest
             ColorPaletteId = segmentResponse.ColorPaletteId,
             Selected = segmentResponse.Selected,
             Reverse = segmentResponse.Reverse,
+            Freeze = segmentResponse.Freeze,
             SegmentState = segmentResponse.SegmentState,
             Brightness = segmentResponse.Brightness,
             Mirror = segmentResponse.Mirror

--- a/src/Kevsoft.WLED/SegmentResponse.cs
+++ b/src/Kevsoft.WLED/SegmentResponse.cs
@@ -84,6 +84,12 @@ public sealed class SegmentResponse
     public bool Reverse { get; set; }
 
     /// <summary>
+    /// freezes/unfreezes the current effect
+    /// </summary>
+    [JsonPropertyName("frz")]
+    public bool Freeze { get; set; }
+
+    /// <summary>
     /// Turns on and off the individual segment. (available since 0.10.0)
     /// </summary>
     [JsonPropertyName("on")]

--- a/test/Kevsoft.WLED.Tests/JsonBuilder.cs
+++ b/test/Kevsoft.WLED.Tests/JsonBuilder.cs
@@ -41,6 +41,7 @@ public class JsonBuilder
                             ""pal"": {seg.ColorPaletteId},
                             ""sel"": {seg.Selected.ToString().ToLower()},
                             ""rev"": {seg.Reverse.ToString().ToLower()},
+                            ""frz"": {seg.Freeze.ToString().ToLower()},
                             ""on"": {seg.SegmentState.ToString().ToLower()},
                             ""bri"": {seg.Brightness}
                             }}";

--- a/test/Kevsoft.WLED.Tests/JsonBuilder.cs
+++ b/test/Kevsoft.WLED.Tests/JsonBuilder.cs
@@ -43,7 +43,8 @@ public class JsonBuilder
                             ""rev"": {seg.Reverse.ToString().ToLower()},
                             ""frz"": {seg.Freeze.ToString().ToLower()},
                             ""on"": {seg.SegmentState.ToString().ToLower()},
-                            ""bri"": {seg.Brightness}
+                            ""bri"": {seg.Brightness},
+                            ""mi"": {seg.Mirror.ToString().ToLower()}
                             }}";
                 }))}],
                 ""tb"": {state.Timebase}


### PR DESCRIPTION
The `frz` (freeze) was missing in the sequence request/response `frz | bool | freezes/unfreezes the current effect`:

https://kno.wled.ge/interfaces/json-api/#contents-of-the-segment-object

Second commit: `mi` was missing in the JsonBuilder of the tests.


