### PR TITLE
Added interface for WLedClient to make it mockable

### DIFF
--- a/src/Kevsoft.WLED/IWLedClient.cs
+++ b/src/Kevsoft.WLED/IWLedClient.cs
@@ -1,0 +1,18 @@
+﻿namespace Kevsoft.WLED;
+
+public interface IWLedClient
+{
+    Task<WLedRootResponse> Get();
+
+    Task<StateResponse> GetState();
+
+    Task<InformationResponse> GetInformation();
+
+    Task<string[]> GetEffects();
+
+    Task<string[]> GetPalettes();
+
+    Task Post(WLedRootRequest request);
+
+    Task Post(StateRequest request);
+}

--- a/src/Kevsoft.WLED/WLedClient.cs
+++ b/src/Kevsoft.WLED/WLedClient.cs
@@ -1,6 +1,6 @@
 ﻿namespace Kevsoft.WLED;
 
-public sealed class WLedClient
+public sealed class WLedClient : IWLedClient
 {
     private readonly HttpClient _client;
 


### PR DESCRIPTION
To test our components an interface for the WLedClient would be nice. Otherwise we must wrap the client. This reduces extra efforts and provides also other users the ability to test their code.